### PR TITLE
Use PAT for shared workflows

### DIFF
--- a/.github/actions/build-push/action.yaml
+++ b/.github/actions/build-push/action.yaml
@@ -1,14 +1,8 @@
 name: 'Build Push'
 description: 'Builds and pushes a Docker image to GHCR.'
 inputs:
-  # User name associated with the PAT.
-  ghcr-username:
-    description: 'Username associated with the PAT used to authenticate to GHCR.'
-    required: true
-  # PAT for authenticating to GHCR, we cannot use the GITHUB_TOKEN because it would not
-  # trigger subsequent actions necessary for continuous deployment.
-  ghcr-password:
-    description: 'PAT token used to authenticate to GHCR.'
+  gh-token:
+    description: 'PAT used for triggering workflows.'
     required: true
   cluster:
     description: 'The development cluster to target.'
@@ -24,8 +18,8 @@ runs:
   - uses: docker/login-action@v1
     with:
       registry: ghcr.io
-      username: '${{ inputs.ghcr-username }}'
-      password: '${{ inputs.ghcr-password }}'
+      username: '${{ github.actor }}'
+      password: '${{ github.token }}'
 
   - uses: docker/metadata-action@v3
     id: meta
@@ -43,7 +37,7 @@ runs:
 
   - shell: bash
     env:
-      GH_TOKEN: '${{ inputs.ghcr-password }}'
+      GH_TOKEN: '${{ inputs.gh-token }}'
       GH_REPO: gramLabs/stormforge-app
     run: |
       gh workflow run promote_image_to_dev.yaml \

--- a/.github/actions/setup-go/action.yaml
+++ b/.github/actions/setup-go/action.yaml
@@ -5,8 +5,8 @@ inputs:
     description: 'The Go version to download (if necessary) and use. Supports semver spec and ranges.'
     default: '~1.17'
     required: false
-  ssh-private-key:
-    description: 'Private SSH key to register in the SSH agent.'
+  gh-token:
+    description: 'PAT used for pulling Go modules.'
     default: ''
     required: false
 
@@ -20,12 +20,13 @@ runs:
 
   - id: go-env
     shell: bash
+    env:
+      ACCESS_TOKEN: '${{ inputs.gh-token }}'
     run: |
-      #git config --global \
-      #  "url.git@github.com:${{ github.repository_owner }}.insteadOf" \
-      #  "https://github.com/${{ github.repository_owner }}"
-      git config --global http.https://github.com/gramLabs/.extraheader \
-          "AUTHORIZATION: basic $(echo -n "x-access-token:${{ inputs.ssh-private-key }}" | base64 -w 0)"
+      if [ -n "${ACCESS_TOKEN}" ]; then
+        git config --global http.https://github.com/gramLabs/.extraheader \
+            "AUTHORIZATION: basic $(echo -n "x-access-token:${ACCESS_TOKEN}" | base64 -w 0)"
+      fi
       go env -w "GOPRIVATE=github.com/${{ github.repository_owner }}"
       echo "::set-output name=go-cache::$(go env GOCACHE)"
       echo "::set-output name=go-mod-cache::$(go env GOMODCACHE)"
@@ -38,8 +39,3 @@ runs:
       key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
       restore-keys: |
         ${{ runner.os }}-go-
-
-#  - uses: webfactory/ssh-agent@v0.5.4
-#    if: inputs.ssh-private-key != ''
-#    with:
-#      ssh-private-key: '${{ inputs.ssh-private-key }}'

--- a/.github/actions/setup-go/action.yaml
+++ b/.github/actions/setup-go/action.yaml
@@ -21,9 +21,11 @@ runs:
   - id: go-env
     shell: bash
     run: |
-      git config --global \
-        "url.git@github.com:${{ github.repository_owner }}.insteadOf" \
-        "https://github.com/${{ github.repository_owner }}"
+      #git config --global \
+      #  "url.git@github.com:${{ github.repository_owner }}.insteadOf" \
+      #  "https://github.com/${{ github.repository_owner }}"
+      git config --global http.https://github.com/gramLabs/.extraheader \
+          "AUTHORIZATION: basic $(echo -n "x-access-token:${{ inputs.ssh-private-key }}" | base64 -w 0)"
       go env -w "GOPRIVATE=github.com/${{ github.repository_owner }}"
       echo "::set-output name=go-cache::$(go env GOCACHE)"
       echo "::set-output name=go-mod-cache::$(go env GOMODCACHE)"
@@ -37,7 +39,7 @@ runs:
       restore-keys: |
         ${{ runner.os }}-go-
 
-  - uses: webfactory/ssh-agent@v0.5.4
-    if: inputs.ssh-private-key != ''
-    with:
-      ssh-private-key: '${{ inputs.ssh-private-key }}'
+#  - uses: webfactory/ssh-agent@v0.5.4
+#    if: inputs.ssh-private-key != ''
+#    with:
+#      ssh-private-key: '${{ inputs.ssh-private-key }}'

--- a/.github/workflows/main-go.yaml
+++ b/.github/workflows/main-go.yaml
@@ -69,8 +69,8 @@ jobs:
       with:
         registry: ghcr.io
         # TODO We aren't using GHCR for events, we can probably use GITHUB_TOKEN
-        username: '${{ secrets.ghcr-username }}'
-        password: '${{ secrets.ghcr-password }}'
+        username: '${{ github.actor }}'
+        password: '${{ github.token }}'
 
     - name: Login to StormForge Registry
       uses: docker/login-action@v1

--- a/.github/workflows/main-go.yaml
+++ b/.github/workflows/main-go.yaml
@@ -19,24 +19,12 @@ on:
         required: false
         type: string
     secrets:
-      # The SSH key should be a deploy key that gives access to gramLabs private repositories
-      ssh-private-key:
-        description: 'Private SSH key to register in the SSH agent.'
-        required: false
-      # User name associated with the PAT.
-      ghcr-username:
-        description: 'Username associated with the PAT used to authenticate to GHCR.'
+      gh-token:
+        description: 'PAT used for triggering workflows and pulling Go modules.'
         required: true
-      # PAT for authenticating to GHCR, we cannot use the GITHUB_TOKEN because it would not
-      # trigger subsequent actions necessary for continuous deployment.
-      ghcr-password:
-        description: 'PAT token used to authenticate to GHCR.'
-        required: true
-      # User for authenticating to the private StormForge registry.
       registry-username:
         description: 'Username for the StormForge registry'
         required: false
-      # Password for authenticating to the private StormForge registry.
       registry-password:
         description: 'Password for the StormForge registry'
         required: false
@@ -54,10 +42,10 @@ jobs:
         fetch-depth: ${{ inputs.fetch-depth }}
 
     - name: Set up Go
-      uses: gramLabs/.github/.github/actions/setup-go@ghcr-pat
+      uses: gramLabs/.github/.github/actions/setup-go@main
       with:
         go-version: '${{ inputs.go-version}}'
-        ssh-private-key: '${{ secrets.ghcr-password }}'
+        gh-token: '${{ secrets.gh-token }}'
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
@@ -68,7 +56,6 @@ jobs:
       uses: docker/login-action@v1
       with:
         registry: ghcr.io
-        # TODO We aren't using GHCR for events, we can probably use GITHUB_TOKEN
         username: '${{ github.actor }}'
         password: '${{ github.token }}'
 
@@ -76,8 +63,8 @@ jobs:
       uses: docker/login-action@v1
       # Hack for testing secret with 'if'
       env:
-        REGISTRY_PASSWORD: '${{ secrets.registry-username }}'
-      if: "${{ env.REGISTRY_PASSWORD != '' }}"
+        REGISTRY_USERNAME: '${{ secrets.registry-username }}'
+      if: "${{ env.REGISTRY_USERNAME != '' }}"
       with:
         registry: registry.stormforge.io
         username: '${{ secrets.registry-username }}'
@@ -93,7 +80,7 @@ jobs:
 
     - name: Deploy image
       env:
-        GH_TOKEN: '${{ secrets.ghcr-password }}'
+        GH_TOKEN: '${{ secrets.gh-token }}'
         GH_REPO: gramLabs/stormforge-app
       run: |
         gh workflow run promote_image_to_dev.yaml \

--- a/.github/workflows/main-go.yaml
+++ b/.github/workflows/main-go.yaml
@@ -54,10 +54,10 @@ jobs:
         fetch-depth: ${{ inputs.fetch-depth }}
 
     - name: Set up Go
-      uses: gramLabs/.github/.github/actions/setup-go@main
+      uses: gramLabs/.github/.github/actions/setup-go@ghcr-pat
       with:
         go-version: '${{ inputs.go-version}}'
-        ssh-private-key: '${{ secrets.ssh-private-key }}'
+        ssh-private-key: '${{ secrets.ghcr-password }}'
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1

--- a/.github/workflows/main-python.yaml
+++ b/.github/workflows/main-python.yaml
@@ -3,25 +3,14 @@ name: Main
 on:
   workflow_call:
     inputs:
-      python-version:
-        description: 'The Python version to download (if necessary) and use.'
-        default: '3.8'
-        required: false
-        type: string
       cluster:
         description: 'The development cluster to target.'
         default: 'dev-1'
         required: false
         type: string
     secrets:
-      # User name associated with the PAT.
-      ghcr-username:
-        description: 'Username associated with the PAT used to authenticate to GHCR.'
-        required: true
-      # PAT for authenticating to GHCR, we cannot use the GITHUB_TOKEN because it would not
-      # trigger subsequent actions necessary for continuous deployment.
-      ghcr-password:
-        description: 'PAT token used to authenticate to GHCR.'
+      gh-token:
+        description: 'PAT used for pushing GHCR images.'
         required: true
 
 jobs:
@@ -37,6 +26,5 @@ jobs:
     - name: Build and Push
       uses: gramLabs/.github/.github/actions/build-push@main
       with:
-        ghcr-username: '${{ secrets.ghcr-username }}'
-        ghcr-password: '${{ secrets.ghcr-password }}'
         cluster: '${{ inputs.cluster }}'
+        gh-token: '${{ secrets.gh-token }}'

--- a/.github/workflows/pull-request-go.yaml
+++ b/.github/workflows/pull-request-go.yaml
@@ -9,8 +9,8 @@ on:
         required: false
         type: string
     secrets:
-      ssh-private-key:
-        description: 'Private SSH key to register in the SSH agent.'
+      gh-token:
+        description: 'PAT used for pulling Go modules.'
         required: false
 
 jobs:
@@ -27,7 +27,7 @@ jobs:
       uses: gramLabs/.github/.github/actions/setup-go@main
       with:
         go-version: '${{ inputs.go-version}}'
-        ssh-private-key: '${{ secrets.ssh-private-key }}'
+        gh-token: '${{ secrets.gh-token }}'
 
     - name: Lint
       uses: golangci/golangci-lint-action@v3
@@ -49,7 +49,7 @@ jobs:
       uses: gramLabs/.github/.github/actions/setup-go@main
       with:
         go-version: '${{ inputs.go-version}}'
-        ssh-private-key: '${{ secrets.ssh-private-key }}'
+        gh-token: '${{ secrets.gh-token }}'
 
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v2
@@ -75,7 +75,7 @@ jobs:
       uses: gramLabs/.github/.github/actions/setup-go@main
       with:
         go-version: '${{ inputs.go-version}}'
-        ssh-private-key: '${{ secrets.ssh-private-key }}'
+        gh-token: '${{ secrets.gh-token }}'
 
     - name: Test
       run: go test -short ./...

--- a/.github/workflows/tag-python.yaml
+++ b/.github/workflows/tag-python.yaml
@@ -13,14 +13,12 @@ on:
         required: true # TODO We should provide a default
         type: string
     secrets:
-      # User for authenticating to the private StormForge registry.
       registry-username:
         description: 'Username for the StormForge registry'
-        required: false
-      # Password for authenticating to the private StormForge registry.
+        required: true
       registry-password:
         description: 'Password for the StormForge registry'
-        required: false
+        required: true
 
 jobs:
 


### PR DESCRIPTION
This PR contains two changes:
1. Stop using a PAT to push images to GHCR, this was only necessary before we were using `gh workflow run` and hadn't been cleaned up
2. Stop using SSH keys to access private Go modules, this only gives access to a single repository