### PR TITLE
added package installation to python setup

### DIFF
--- a/.github/actions/setup-python/action.yaml
+++ b/.github/actions/setup-python/action.yaml
@@ -18,4 +18,5 @@ runs:
   - shell: bash
     run: |
       python -m pip install --upgrade pip setuptools wheel
-      find . -name requirements.txt -exec pip install -r {} \;
+      pip install -r requirements.txt
+      python setup.py develop


### PR DESCRIPTION
I decided to finally start consolidating the python repos on the core workflows. Right now only the admin-panel-api is using them. I'm a little concerned this change will break the caching of the pip install because the package version for repo being test will change every time but don't know enough about how the cache works to be sure. If it does we can fix it by splitting out the setup.py call to a separate step and create the cache before that