### PR TITLE
pull-request-go: Increase timeout to 3m

### DIFF
--- a/.github/workflows/pull-request-go.yaml
+++ b/.github/workflows/pull-request-go.yaml
@@ -32,7 +32,7 @@ jobs:
       uses: golangci/golangci-lint-action@v3
       with:
         version: latest
-        args: -E goimports,stylecheck --timeout 2m
+        args: -E goimports,stylecheck --timeout 3m
         skip-pkg-cache: true
         skip-build-cache: true
 


### PR DESCRIPTION
We recently increased the timeout for the go linter to two minutes (see #12) but apparently that is still not always enough: Multiple times I had PRs failing in https://github.com/gramLabs/stormforge-cli failing due to two minutes timeout.

This PR increases the timeout to 3m.


Example for failing build: https://github.com/gramLabs/stormforge-cli/actions/runs/2597408313/attempts/1