### PR TITLE
Prefer tag to short hash

### DIFF
--- a/.github/workflows/main-go.yaml
+++ b/.github/workflows/main-go.yaml
@@ -100,8 +100,13 @@ jobs:
         GH_TOKEN: '${{ secrets.gh-token }}'
         GH_REPO: gramLabs/stormforge-app
       run: |
+        if [ "${GITHUB_REF_TYPE}" == "tag" ]; then
+          tag="${GITHUB_REF##*/v}"
+        else
+          tag="sha-$(git rev-parse --short HEAD)"
+        fi
         gh workflow run promote_image_to_dev.yaml \
           --ref main \
-          -f image="ghcr.io/${{ github.repository }}:sha-$(git rev-parse --short HEAD)" \
+          -f image="ghcr.io/${{ github.repository }}:${tag}" \
           -f cluster="${{ inputs.cluster }}"
 


### PR DESCRIPTION
This changes the image tag we pass to `stormforge-app`; normally this isn't an issue because only a small number of repositories build `on: tag`. However, for the CLI (and eventually the Live images), if we push the hash instead instead of the tag, the images won't be pushed from GHCR to ECR/Harbor.