### PR TITLE
Use PAT for GoReleaser

### DIFF
--- a/.github/workflows/main-go.yaml
+++ b/.github/workflows/main-go.yaml
@@ -80,7 +80,7 @@ jobs:
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v3
       env:
-        GITHUB_TOKEN: '${{ github.token }}'
+        GITHUB_TOKEN: '${{ secrets.gh-token }}'
       with:
         version: latest
         args: release


### PR DESCRIPTION
Currently GoReleaser is using the `github.token` which cannot trigger subsequent actions. Normally this isn't a problem, however the CLI is trying to hook the "create release" event to sign and upload binaries. Using the PAT will allow the create release action to run when GoReleaser creates the release.

As a side effect, I believe gramBot will be attributed in the releases instead of the github-actions bot.