### PR TITLE
Allow GoReleaser metadata to propagate out of workflow

### DIFF
--- a/.github/workflows/main-go.yaml
+++ b/.github/workflows/main-go.yaml
@@ -36,6 +36,13 @@ on:
       registry-password:
         description: 'Password for the StormForge registry'
         required: false
+    outputs:
+      artifacts:
+        description: Build result artifacts.
+        value: ${{ jobs.deploy.outputs.artifacts }}
+      metadata:
+        description: Build result metadata.
+        value: ${{ jobs.deploy.outputs.metadata }}
 
 jobs:
 
@@ -43,6 +50,9 @@ jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
+    outputs:
+      artifacts: ${{ steps.goreleaser.outputs.artifacts }}
+      metadata: ${{ steps.goreleaser.outputs.metadata }}
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -81,6 +91,7 @@ jobs:
         password: '${{ secrets.registry-password }}'
 
     - name: Run GoReleaser
+      id: goreleaser
       uses: goreleaser/goreleaser-action@v3
       env:
         GITHUB_TOKEN: '${{ secrets.gh-token }}'


### PR DESCRIPTION
This PR changes the `main-go` reusable workflow so that the GoReleaser output is available to callers.

For example, consider the following `main.yaml` workflow that just prints the version number computed by GoReleaser:

```yaml
name: Main
on:
  push:
    branches:
    - main
    tags:
    - v*

jobs:
  go:
    name: Go
    uses: gramLabs/.github/.github/workflows/main-go.yaml@main
    secrets:
      gh-token: ${{ secrets.SERVICES_PACKAGE_PAT }}

  example:
    runs-on: ubuntu-latest
    needs: go
    steps:
    - run: |
        VERSION='${{ fromJson(needs.go.outputs.metadata).version }}'
        echo "Got $VERSION"
```

The format of the `artifacts` and `metadata` outputs match what GoReleaser produces in the `dist/` directory (i.e. the `artifacts` output is just the `dist/artifacts.json` file and `metadata` is the `dist/metadata.json` file. This allows subsequent jobs to reuse the exact values GoReleaser used rather than trying to reconstruct them or guess them.