### PR TITLE
feat: OL-805 multi-platform support on recommender

### DIFF
--- a/.github/workflows/tag-python.yaml
+++ b/.github/workflows/tag-python.yaml
@@ -30,6 +30,11 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
 
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+      with:
+        platforms: 'arm64'
+
     - name: Setup Buildx
       uses: docker/setup-buildx-action@v2
 
@@ -47,11 +52,11 @@ jobs:
         images: registry.stormforge.io/${{ inputs.image-name }}
         flavor: latest=true
         tags: 'type=semver,pattern={{version}}'
-
     - name: Build and push
       uses: docker/build-push-action@v3
       with:
         context: .
         push: true
+        platforms: linux/amd64,linux/arm64
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Added docker/QEMU and calling multiple platforms as part of buildx. Added some extra docker labels to follow the same standard from the goreleaser. Documented the test of this workflow changes on Jira OL-805.
Signed-off-by: Rafael Brito <rafa@stormforge.io>