### PR TITLE
Use the GoReleaser output for promotion

### DIFF
--- a/.github/workflows/main-go.yaml
+++ b/.github/workflows/main-go.yaml
@@ -115,13 +115,8 @@ jobs:
         GH_TOKEN: '${{ secrets.gh-token }}'
         GH_REPO: gramLabs/stormforge-app
       run: |
-        if [ "${GITHUB_REF_TYPE}" == "tag" ]; then
-          tag="${GITHUB_REF##*/v}"
-        else
-          tag="sha-$(git rev-parse --short HEAD)"
-        fi
         gh workflow run promote_image_to_dev.yaml \
           --ref main \
-          -f image="ghcr.io/${{ github.repository }}:${tag}" \
+          -f image="ghcr.io/${{ github.repository }}:${{ fromJson(steps.goreleaser.outputs.metadata).version }}" \
           -f cluster="${{ inputs.cluster }}"
 


### PR DESCRIPTION
This builds on #17 and leverages the GoReleaser output to more accurately compute the image name that was produced.

Effectively, GoReleaser does not emit anything for the Docker images like it does for other artfacts (i.e. there is no `./dist/dockers.json`); so the best we can do is rely on convention for what the image name will be.

The current logic using environment variables is an attempt to mimic GoReleaser's logic for computing the `.Version` value, but now we can just get the actual value from the step output.

This still assumes the `goreleaser.yaml` will contain either a `dockers[].image_templates[]` or a `docker_manifests[].name_template` of `"ghcr.io/gramlabs/{{.ProjectName}}:{{.Version}}"`.

Note that `promote_image_to_dev.yaml` accepts invalid, mixed-case image names to account for the fact that GitHub Actions does not have a "to lower" expression function. For example, the GitHub Actions expression `ghcr.io/${{ github.repository}}` will be `ghcr.io/gramLabs/foobar` while the GoReleaser template `ghcr.io/gramlabs/{{.ProjectName}}` will be `ghcr.io/gramlabs/foobar`.