### PR TITLE
Misc. clean up

### DIFF
--- a/.github/actions/setup-go/action.yaml
+++ b/.github/actions/setup-go/action.yaml
@@ -1,11 +1,6 @@
 name: 'Setup Go'
 description: 'Configures Go and sets up Git for private module access.'
 inputs:
-  go-version:
-    description: 'The Go version to download (if necessary) and use. Supports semver spec and ranges.'
-    default: '~1.17'
-    required: false
-    deprecationMessage: 'The Go version is now read directly from the ./go.mod file'
   gh-token:
     description: 'PAT used for pulling Go modules.'
     default: ''

--- a/.github/actions/setup-go/action.yaml
+++ b/.github/actions/setup-go/action.yaml
@@ -1,5 +1,5 @@
 name: 'Setup Go'
-description: 'Configures Go and sets up Git/SSH for private module access.'
+description: 'Configures Go and sets up Git for private module access.'
 inputs:
   go-version:
     description: 'The Go version to download (if necessary) and use. Supports semver spec and ranges.'

--- a/.github/actions/setup-python/action.yaml
+++ b/.github/actions/setup-python/action.yaml
@@ -10,7 +10,7 @@ runs:
   using: "composite"
   steps:
 
-  - uses: actions/setup-python@v3
+  - uses: actions/setup-python@v4
     with:
       python-version: '${{ inputs.python-version }}'
       cache: 'pip'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
   directory: "/"
   schedule:
     interval: "daily"
+- package-ecosystem: "github-actions"
+  directory: "/.github/actions"
+  schedule:
+    interval: "daily"

--- a/.github/workflows/main-go.yaml
+++ b/.github/workflows/main-go.yaml
@@ -61,6 +61,8 @@ jobs:
 
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v2
+      with:
+        platforms: 'arm64'
 
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2

--- a/.github/workflows/main-go.yaml
+++ b/.github/workflows/main-go.yaml
@@ -3,11 +3,6 @@ name: Main
 on:
   workflow_call:
     inputs:
-      go-version:
-        description: 'Currently ignored in favor of the go.mod file.'
-        default: '~1.17'
-        required: false
-        type: string
       fetch-depth:
         description: 'The fetch depth for checking out code. Must be 0 for GoReleaser to recognize tags.'
         default: 1

--- a/.github/workflows/pull-request-go.yaml
+++ b/.github/workflows/pull-request-go.yaml
@@ -2,12 +2,6 @@ name: Pull Request
 
 on:
   workflow_call:
-    inputs:
-      go-version:
-        description: 'Currently ignored in favor of the go.mod file.'
-        default: '~1.17'
-        required: false
-        type: string
     secrets:
       gh-token:
         description: 'PAT used for pulling Go modules.'

--- a/.github/workflows/tag-python.yaml
+++ b/.github/workflows/tag-python.yaml
@@ -52,6 +52,7 @@ jobs:
         images: registry.stormforge.io/${{ inputs.image-name }}
         flavor: latest=true
         tags: 'type=semver,pattern={{version}}'
+
     - name: Build and push
       uses: docker/build-push-action@v3
       with:


### PR DESCRIPTION
* Apply @brito-rafa's change for QEMU platform restrictions to the Go builds
* Remove deprecated `go-version` input (prereq PRs [here](https://github.com/gramLabs/stormforge-cloud/pull/36) and [here](https://github.com/gramLabs/optimize-live-controller/pull/55))
* Upgrade `setup-python` (and try to get Dependabot to recognize it next time)