### PR TITLE
Temporarily use workflow ID instead of name

### DIFF
--- a/.github/actions/build-push/action.yaml
+++ b/.github/actions/build-push/action.yaml
@@ -40,7 +40,7 @@ runs:
       GH_TOKEN: '${{ inputs.gh-token }}'
       GH_REPO: gramLabs/stormforge-app
     run: |
-      gh workflow run promote_image_to_dev.yaml \
+      gh workflow run 18788892 \
         --ref main \
         -f image="${{ steps.meta.outputs.tags }}" \
         -f cluster="${{ inputs.cluster }}"

--- a/.github/workflows/main-go.yaml
+++ b/.github/workflows/main-go.yaml
@@ -112,7 +112,7 @@ jobs:
         GH_TOKEN: '${{ secrets.gh-token }}'
         GH_REPO: gramLabs/stormforge-app
       run: |
-        gh workflow run promote_image_to_dev.yaml \
+        gh workflow run 18788892 \
           --ref main \
           -f image="ghcr.io/${{ github.repository }}:${{ fromJson(steps.goreleaser.outputs.metadata).version }}" \
           -f cluster="${{ inputs.cluster }}"


### PR DESCRIPTION
gh v2.16.0 has a bug where only ".yml" workflow files can be used; until v2.16.1 is available in the runners image we need to reference the workflows by ID.