### PR TITLE
Misc. Updates

### DIFF
--- a/.github/actions/build-push/action.yaml
+++ b/.github/actions/build-push/action.yaml
@@ -34,6 +34,8 @@ runs:
       push: true
       tags: ${{ steps.meta.outputs.tags }}
       labels: ${{ steps.meta.outputs.labels }}
+      cache-from: type=gha
+      cache-to: type=gha
 
   - shell: bash
     env:

--- a/.github/actions/build-push/action.yaml
+++ b/.github/actions/build-push/action.yaml
@@ -39,10 +39,9 @@ runs:
 
   - shell: bash
     env:
-      GH_TOKEN: '${{ inputs.gh-token }}'
       GH_REPO: gramLabs/stormforge-app
+      GH_TOKEN: ${{ inputs.gh-token }}
     run: |
-      gh workflow run 18788892 \
-        --ref main \
+      gh workflow run promote_image_to_dev.yaml \
         -f image="${{ steps.meta.outputs.tags }}" \
         -f cluster="${{ inputs.cluster }}"

--- a/.github/actions/build-push/action.yaml
+++ b/.github/actions/build-push/action.yaml
@@ -13,7 +13,7 @@ runs:
   using: "composite"
   steps:
 
-  - uses: docker/setup-buildx-action@v1
+  - uses: docker/setup-buildx-action@v2
 
   - uses: docker/login-action@v2
     with:
@@ -21,7 +21,7 @@ runs:
       username: '${{ github.actor }}'
       password: '${{ github.token }}'
 
-  - uses: docker/metadata-action@v3
+  - uses: docker/metadata-action@v4
     id: meta
     with:
       images: ghcr.io/${{ github.repository }}

--- a/.github/workflows/main-go.yaml
+++ b/.github/workflows/main-go.yaml
@@ -109,11 +109,10 @@ jobs:
 
     - name: Deploy image
       env:
-        GH_TOKEN: '${{ secrets.gh-token }}'
         GH_REPO: gramLabs/stormforge-app
+        GH_TOKEN: ${{ secrets.gh-token }}
       run: |
-        gh workflow run 18788892 \
-          --ref main \
+        gh workflow run promote_image_to_dev.yaml \
           -f image="ghcr.io/${{ github.repository }}:${{ fromJson(steps.goreleaser.outputs.metadata).version }}" \
           -f cluster="${{ inputs.cluster }}"
 

--- a/.github/workflows/main-go.yaml
+++ b/.github/workflows/main-go.yaml
@@ -59,11 +59,6 @@ jobs:
       with:
         gh-token: '${{ secrets.gh-token }}'
 
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
-      with:
-        platforms: 'arm64'
-
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v2
       with:

--- a/.github/workflows/tag-python.yaml
+++ b/.github/workflows/tag-python.yaml
@@ -61,3 +61,5 @@ jobs:
         platforms: linux/amd64,linux/arm64
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
+        cache-from: type=gha
+        cache-to: type=gha


### PR DESCRIPTION
This PR contains some housekeeping changes:
1. A few Actions needed version bumps
2. We can refer to workflows by name again
3. The Go builds do not actually need QEMU (we do the cross compilation in Go on the runner)
4. Enabled the Docker build cache (finally)