### PR TITLE
Helm workflows

### DIFF
--- a/.github/actions/deploy-helm-chart/action.yaml
+++ b/.github/actions/deploy-helm-chart/action.yaml
@@ -1,0 +1,55 @@
+name: Deploy Helm Chart
+description: Builds and pushes a Helm chart to GHCR.
+inputs:
+  gh-token:
+    description: PAT used for triggering workflows.
+    required: true
+  registry:
+    description: Registry to push the Helm chart to.
+    required: true
+    default: ghcr.io/${{ github.repository_owner }}
+  chart:
+    description: Name of the chart to build and push.
+    required: true
+  version:
+    description: Version of the chart to build. Can be included as a "/v" suffix on the chart name.
+    required: false
+    default: ''
+  app-version:
+    description: Application version to include in the chart.
+    required: false
+    default: ''
+
+runs:
+  using: "composite"
+  steps:
+
+  - uses: docker/login-action@v2
+    with:
+      registry: ghcr.io
+      username: ${{ github.actor }}
+      password: ${{ github.token }}
+
+  - shell: bash
+    id: helm-chart
+    env:
+      REGISTRY: ${{ inputs.registry }}
+      CHART: ${{ inputs.chart }}
+      VERSION: ${{ inputs.version }}
+      APP_VERSION: ${{ inputs.app-version }}
+    run: |
+      VERSION=${VERSION-${CHART##*/v}}
+      CHART=${CHART%%/v*}
+      REGISTRY=${REGISTRY,,}
+      echo "image=${REGISTRY}/${CHART}:${VERSION}" >> $GITHUB_OUTPUT
+      
+      helm package "./charts/${CHART}" --version "${VERSION}" --app-version "${APP_VERSION}" --destination "./dist"
+      helm push "./dist/${CHART}-${VERSION}.tgz" "oci://${REGISTRY}"
+
+  - shell: bash
+    env:
+      GH_REPO: gramLabs/stormforge-app
+      GH_TOKEN: ${{ secrets.SERVICES_PACKAGE_PAT }}
+    run: |
+      gh workflow run promote_image_to_dev.yaml \
+        -f image="${{ steps.helm-chart.outputs.image }}"

--- a/.github/workflows/pull-request-helm.yaml
+++ b/.github/workflows/pull-request-helm.yaml
@@ -1,0 +1,41 @@
+name: Pull Request
+
+on:
+  workflow_call: {}
+
+jobs:
+
+  # Runs chart-testing over the Helm charts
+  chart-test:
+    name: Helm Chart Testing
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.9'
+
+    - name: Set up Helm Chart Testing
+      uses: helm/chart-testing-action@v2
+
+    - name: List changed
+      id: list-changed
+      run: |
+        if [[ -n "$(ct list-changed --target-branch $GITHUB_BASE_REF)" ]] ; then
+          echo "changed=true" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Lint
+      run: ct lint --target-branch $GITHUB_BASE_REF
+
+    - name: Create kind cluster
+      uses: helm/kind-action@v1
+      if: steps.list-changed.outputs.changed
+
+    - name: Install
+      run: ct install


### PR DESCRIPTION
This PR includes a shared workflow for linting/testing Helm charts from the `/charts/` directory of a repository.

The `deploy-helm-chart` action can be used to build (package) the Helm chart, push it to GHCR and trigger a deploy against the stormforge-app repository. Note that this action accepts either a bare chart name or chart name with a version: this is meant to allow repositories to have separate tags for the Helm charts. For example, if a chart is located in the `/charts/foobar` directory, the repository can be tagged with `foobar/v1.0.0` and the `deploy-helm-chart` can be invoked with `chart: foobar/v1.0.0` (instead of `chart: foobar` and `version: 1.0.0`). Additionally, the `registry` input will be lower cased so `gramLabs` doesn't cause problems.