### PR TITLE
fix: ct install target branch so it can see charts

### DIFF
--- a/.github/workflows/pull-request-helm.yaml
+++ b/.github/workflows/pull-request-helm.yaml
@@ -38,5 +38,5 @@ jobs:
       if: steps.list-changed.outputs.changed
 
     - name: Install
-      run: ct install
+      run: ct install --target-branch $GITHUB_BASE_REF
       if: steps.list-changed.outputs.changed


### PR DESCRIPTION
ct install's default behavior is strange to me. You either need to specify a branch or --all to get it to work. Even in the other stormforger/helm-charts repo, we target the main branch with it. 

This change will make it so ct install will actually see the chart on the pr and run properly... At least it works locally when I make these changes. 

If you want to see it failing - https://github.com/gramLabs/stormforge-agent/actions/runs/3896954252/jobs/6654085362

Here is our public charts workflow - https://github.com/thestormforge/helm-charts/blob/main/.github/workflows/lint-test.yaml
