### PR TITLE
fix: pining buildkit until we have a more permanant solution

### DIFF
--- a/.github/actions/build-push/action.yaml
+++ b/.github/actions/build-push/action.yaml
@@ -13,7 +13,15 @@ runs:
   using: "composite"
   steps:
 
-  - uses: docker/setup-buildx-action@v2
+  - uses: docker/setup-buildx-action@v2.2.1
+    id: buildx
+    with:
+      version: "latest"
+      install: true
+      # pin buildkit so we do not build attestation + bom manifests for now
+      # see https://stormkore.slack.com/archives/C01KUGAJNF6/p1673530297642719
+      driver-opts: |
+        image=moby/buildkit:v0.10.6
 
   - uses: docker/login-action@v2
     with:


### PR DESCRIPTION
Sibling PR to https://github.com/stormforger/forge/pull/4875

Skopeo currently failing in the release workflows.

https://github.com/gramLabs/stormforge-app/actions/runs/3969142178/jobs/6803228771