### PR TITLE
actions/build-push: Add 'build-args' input for image

### DIFF
--- a/.github/actions/build-push/action.yaml
+++ b/.github/actions/build-push/action.yaml
@@ -8,6 +8,10 @@ inputs:
     description: 'The development cluster to target.'
     default: 'dev-1'
     required: false
+  build-args:
+    description: 'Build arguments for the image'
+    required: false
+    default: ''
 
 runs:
   using: "composite"
@@ -37,6 +41,7 @@ runs:
       labels: ${{ steps.meta.outputs.labels }}
       cache-from: type=gha
       cache-to: type=gha
+      build-args: ${{ inputs.build-args }}
 
   - shell: bash
     env:


### PR DESCRIPTION
https://gramlabs.atlassian.net/browse/PERFOPT-383

This add a new input `build-args` to the `build-push` action allowing build arguments for the `Dockerfile`.

### Example Usage

```yaml
    - name: Read python version
      id: python
      run: |
        printf "python-version=$(cat .python-version)" >> "$GITHUB_OUTPUT"

    - name: Build and Push
      uses: gramLabs/.github/.github/actions/build-push@build-args
      with:
        gh-token: ${{ secrets.SERVICES_PACKAGE_PAT }}
        build-args:
          PYTHON_VERSION=${{ steps.python.outputs.python-version }}
```

Docs: https://docs.docker.com/engine/reference/commandline/build/#build-arg