### PR TITLE
Expose Helm lint and test options

### DIFF
--- a/.github/workflows/pull-request-helm.yaml
+++ b/.github/workflows/pull-request-helm.yaml
@@ -1,7 +1,13 @@
 name: Pull Request
 
 on:
-  workflow_call: {}
+  workflow_call:
+    inputs:
+      check-version-increment:
+        description: "If true (default), `ct lint` will check for chart version increment"
+        default: true
+        required: false
+        type: boolean
 
 jobs:
 
@@ -31,7 +37,7 @@ jobs:
         fi
 
     - name: Lint
-      run: ct lint --target-branch $GITHUB_BASE_REF
+      run: ct lint --check-version-increment=${{ inputs.check-version-increment }} --target-branch $GITHUB_BASE_REF
 
     - name: Create kind cluster
       uses: helm/kind-action@v1

--- a/.github/workflows/pull-request-helm.yaml
+++ b/.github/workflows/pull-request-helm.yaml
@@ -8,6 +8,12 @@ on:
         default: true
         required: false
         type: boolean
+      check-install:
+        description: "If true (default), install the chart on a Kind cluster and verify successful deployment"
+        default: true
+        required: false
+        type: boolean
+
 
 jobs:
 
@@ -41,8 +47,8 @@ jobs:
 
     - name: Create kind cluster
       uses: helm/kind-action@v1
-      if: steps.list-changed.outputs.changed
+      if: ${{ inputs.check-install == 'true' && steps.list-changed.outputs.changed == 'true' }}
 
     - name: Install
       run: ct install --target-branch $GITHUB_BASE_REF
-      if: steps.list-changed.outputs.changed
+      if: ${{ inputs.check-install == 'true' && steps.list-changed.outputs.changed == 'true' }}


### PR DESCRIPTION
Nobody increments the Chart.yaml version in pull requests, but checking for that causes every Helm lint job to fail.

By exposing this behavior in an input, we can disable it for pull-request workflows. Leaves behavior unchanged unless a consuming repo sets the input.

Additionally expose an option to skip install tests. This supports situations like stormforge-agent which currently doesn't have a working install test, since the workload-agent container will always enter CrashLoopBackoff since we aren't giving it valid StormForge credentials in the runner install job(s).