### PR TITLE
Add build-args input to workflows/main-python

### DIFF
--- a/.github/workflows/main-python.yaml
+++ b/.github/workflows/main-python.yaml
@@ -3,6 +3,11 @@ name: Main
 on:
   workflow_call:
     inputs:
+      build-args:
+        description: 'Build arguments for the image'
+        required: false
+        default: ''
+        type: string
       cluster:
         description: 'The development cluster to target.'
         default: 'dev-1'
@@ -26,5 +31,6 @@ jobs:
     - name: Build and Push
       uses: gramLabs/.github/.github/actions/build-push@main
       with:
+        build-args: '${{ inputs.build-args }}'
         cluster: '${{ inputs.cluster }}'
         gh-token: '${{ secrets.gh-token }}'


### PR DESCRIPTION
While working on https://github.com/gramLabs/live-worker/pull/177 I noticed, that we cannot pass build arguments to `.github/actions/build-push` (added in https://github.com/gramLabs/.github/pull/33) in `workflows/main-python`.