### PR TITLE
fix: Increase go lint timeout

### DIFF
--- a/.github/workflows/pull-request-go.yaml
+++ b/.github/workflows/pull-request-go.yaml
@@ -26,7 +26,7 @@ jobs:
       uses: golangci/golangci-lint-action@v3
       with:
         version: latest
-        args: -E goimports,stylecheck --timeout 3m
+        args: -E goimports,stylecheck --timeout 10m
         skip-pkg-cache: true
         skip-build-cache: true
 


### PR DESCRIPTION
Were starting to hit the 3m timeout for some of the agent builds. ref: https://github.com/gramLabs/stormforge-agent/actions/runs/5603806758/jobs/10256903073#step:4:30