### PR TITLE
Change cache implementation for linter

### DIFF
--- a/.github/workflows/pull-request-go.yaml
+++ b/.github/workflows/pull-request-go.yaml
@@ -18,17 +18,24 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Set up Go
-      uses: gramLabs/.github/.github/actions/setup-go@main
+      uses: actions/setup-go@v4
       with:
-        gh-token: '${{ secrets.gh-token }}'
+        go-version-file: 'go.mod'
+        cache: false
+    
+    - name: Go Env
+      run: |
+        if [ -n "${{ secrets.gh-token }}" ]; then
+          git config --global http.https://github.com/gramLabs/.extraheader \
+            "AUTHORIZATION: basic $(echo -n "x-access-token:${{ secrets.gh-token }}" | base64 -w 0)"
+        fi
+        go env -w "GOPRIVATE=github.com/${{ github.repository_owner }}"
 
     - name: Lint
       uses: golangci/golangci-lint-action@v3
       with:
         version: latest
-        args: -E goimports,stylecheck --timeout 3m
-        skip-pkg-cache: true
-        skip-build-cache: true
+        args: -E goimports,stylecheck
 
   # Runs the build to ensure nothing is overtly broken.
   build:


### PR DESCRIPTION
This changes the Lint job to use the stock `setup-go` and gives golangci-lint full ownership of the Go cache to see if it improves linter performance.

It's unclear if this is functionally any different from what we have, however it does prove to be an effective change we can go back and add a `cache` input to our own `setup-go` to reduce the duplication in the authorization code. If things do not improve, we can just revert this change back out.

Note that I dropped the explicit timeout configuration which actually shortens the timeout from 3m to 1m (which is considerably less then the example on the golangci-lint page: a whooping 30m).