### PR TITLE
Chore: bump golangci/golangci-lint-action to v4 to address node.js 16 deprecation

### DIFF
--- a/.github/workflows/pull-request-go.yaml
+++ b/.github/workflows/pull-request-go.yaml
@@ -23,7 +23,7 @@ jobs:
         gh-token: '${{ secrets.gh-token }}'
 
     - name: Lint
-      uses: golangci/golangci-lint-action@v3
+      uses: golangci/golangci-lint-action@v4
       with:
         version: latest
         args: -E goimports,stylecheck --timeout 10m


### PR DESCRIPTION
See https://github.com/golangci/golangci-lint-action/releases/tag/v4.0.0