### PR TITLE
Include ref_name field when calling promote_image

### DIFF
--- a/.github/actions/build-push/action.yaml
+++ b/.github/actions/build-push/action.yaml
@@ -44,4 +44,4 @@ runs:
       GH_REPO: gramLabs/stormforge-app
       GH_TOKEN: ${{ inputs.gh-token }}
     run: |
-      gh workflow run promote_image.yaml -f image="${{ steps.meta.outputs.tags }}"
+      gh workflow run promote_image.yaml -f image="${{ steps.meta.outputs.tags }}" -f ref_name="${{ github.ref_name }}"

--- a/.github/actions/deploy-helm-chart/action.yaml
+++ b/.github/actions/deploy-helm-chart/action.yaml
@@ -52,4 +52,4 @@ runs:
       GH_REPO: gramLabs/stormforge-app
       GH_TOKEN: ${{ inputs.gh-token }}
     run: |
-      gh workflow run promote_image.yaml -f image="${{ steps.helm-chart.outputs.image }}"
+      gh workflow run promote_image.yaml -f image="${{ steps.helm-chart.outputs.image }}" -f ref_name="${{ github.ref_name }}"

--- a/.github/workflows/main-go-service.yaml
+++ b/.github/workflows/main-go-service.yaml
@@ -116,4 +116,4 @@ jobs:
         GH_TOKEN: ${{ secrets.gh-token }}
       run: |
         tags=( ${{ steps.meta.outputs.tags }} )
-        gh workflow run promote_image.yaml -f image="${tags}"
+        gh workflow run promote_image.yaml -f image="${tags}" -f ref_name="${{ github.ref_name }}"

--- a/.github/workflows/main-go-software.yaml
+++ b/.github/workflows/main-go-software.yaml
@@ -202,4 +202,4 @@ jobs:
         GH_TOKEN: ${{ secrets.gh-token }}
       run: |
         tags=( ${{ steps.meta.outputs.tags }} )
-        gh workflow run promote_image.yaml -f image="${tags}"
+        gh workflow run promote_image.yaml -f image="${tags}" -f ref_name="${{ github.ref_name }}"


### PR DESCRIPTION
See [stormforge-app#746](https://github.com/gramLabs/stormforge-app/pull/746), this PR includes explicit values for `ref_name` (overriding the default value of `main`).