### PR TITLE
Disable Docker build summaries

### DIFF
--- a/.github/actions/build-push/action.yaml
+++ b/.github/actions/build-push/action.yaml
@@ -29,6 +29,8 @@ runs:
       tags: type=sha
 
   - uses: docker/build-push-action@v6
+    env:
+      DOCKER_BUILD_SUMMARY: "false"
     with:
       context: .
       push: true

--- a/.github/workflows/main-go-service.yaml
+++ b/.github/workflows/main-go-service.yaml
@@ -98,6 +98,8 @@ jobs:
 
     - name: Build and push
       uses: docker/build-push-action@v6
+      env:
+        DOCKER_BUILD_SUMMARY: "false"
       with:
         platforms: linux/amd64
         file: ./Dockerfile

--- a/.github/workflows/main-go-software.yaml
+++ b/.github/workflows/main-go-software.yaml
@@ -159,6 +159,8 @@ jobs:
       uses: docker/build-push-action@v6
       if: ${{ steps.platforms.outputs.context_amd64 }}
       id: build-amd64
+      env:
+        DOCKER_BUILD_SUMMARY: "false"
       with:
         platforms: linux/amd64
         file: ./Dockerfile
@@ -175,6 +177,8 @@ jobs:
       uses: docker/build-push-action@v6
       if: ${{ steps.platforms.outputs.context_arm64 }}
       id: build-arm64
+      env:
+        DOCKER_BUILD_SUMMARY: "false"
       with:
         platforms: linux/arm64
         file: ./Dockerfile

--- a/.github/workflows/tag-python.yaml
+++ b/.github/workflows/tag-python.yaml
@@ -55,6 +55,8 @@ jobs:
 
     - name: Build and push
       uses: docker/build-push-action@v6
+      env:
+        DOCKER_BUILD_SUMMARY: "false"
       with:
         context: .
         push: true


### PR DESCRIPTION
This PR disables Docker build summaries (which were enabled by default by the last update).