### PR TITLE
Lock golangci-lint to 1.x for now

### DIFF
--- a/.github/workflows/pull-request-go.yaml
+++ b/.github/workflows/pull-request-go.yaml
@@ -25,7 +25,7 @@ jobs:
     - name: Lint
       uses: golangci/golangci-lint-action@v7
       with:
-        version: latest
+        version: v1.64
         args: -E goimports,stylecheck --timeout 10m
 
   # Runs the build to ensure nothing is overtly broken.


### PR DESCRIPTION
Looks like there was a SemVer major version release, and the args we set here don't work in 2.x. Suggest for now locking to 1.x, can consider how to get to 2.x after.