### PR TITLE
Use previous version of golangci-lint action

### DIFF
--- a/.github/workflows/pull-request-go.yaml
+++ b/.github/workflows/pull-request-go.yaml
@@ -23,7 +23,7 @@ jobs:
         gh-token: '${{ secrets.gh-token }}'
 
     - name: Lint
-      uses: golangci/golangci-lint-action@v7
+      uses: golangci/golangci-lint-action@v6
       with:
         version: v1.64
         args: -E goimports,stylecheck --timeout 10m


### PR DESCRIPTION
Newer versions of the action don't support golangci-lint v1.

"invalid version string 'v1.64', golangci-lint v1 is not supported by golangci-lint-action v7."