### PR TITLE
Update golangci-lint-action to v7

### DIFF
--- a/.github/workflows/pull-request-go.yaml
+++ b/.github/workflows/pull-request-go.yaml
@@ -22,11 +22,32 @@ jobs:
       with:
         gh-token: '${{ secrets.gh-token }}'
 
+    - name: Configure Linter
+      run: |
+        cat << EOF > "${{ runner.temp }}/.golangci.yaml"
+        version: "2"
+        linters:
+          default: none
+          enable:
+          - staticcheck
+          settings:
+            staticcheck:
+              checks:
+              - ST*
+              - -ST1000
+              - -ST1020
+              - -ST1021
+              - -ST1022
+        formatters:
+          enable:
+          - gofmt
+          - goimports
+        EOF
+
     - name: Lint
-      uses: golangci/golangci-lint-action@v6
+      uses: golangci/golangci-lint-action@v7
       with:
-        version: v1.64
-        args: -E goimports,stylecheck --timeout 10m
+        args: '--config="${{ runner.temp }}/.golangci.yaml"'
 
   # Runs the build to ensure nothing is overtly broken.
   build:


### PR DESCRIPTION
This PR upgrades the `golangci-lint-action` from v6 to v7, this forces the upgrade from `golangci-lint` v1.x to v2.x.

With v2 it is not longer viable to run `golangci-lint` without a configuration file. The original goal of running without a configuration file was always to avoid the potential for skew introduced by per-repository configurations: effectively there was a "central configuration" enforced by the way the linter was invoked. To preserve that behavior, a fixed configuration file is created in the runner temporary directory and used to run the linter. This has the unfortunate side effect of making it more difficult for developers to reproduce the behavior locally: previously you just needed to know that running `golangci-lint run -E goimports,stylecheck` would produce consistent results with the pull request linter; now you need the fixed configuration file. **My current recommendation is to copy the configuration from pull request workflow and save it locally as `~/.golangci.yaml`, this will allow you to use `golangci-lint run` without arguments.**

All Go developers are encouraged to save the configuration locally and upgrade `golangci-lint` to v2. We may want to discus an alternative for distributing the common configuration file in the future so that is easier to keep up-to-date with any changes, however that is out of scope for this PR.

The current configuration matches the existing behavior as closely as possible (note that the `stylecheck` from v1 is just the `ST*` ruleset from `staticcheck`, in v2 they removed the alias that let you run them separately). I disabled a few rules that we are not strictly adhering to (primarily around the format and structure of comments) to simplify the transition to v2. The other main difference I noticed is that `gofmt` is assumed to be run with the `-s` option: I have opened a few PRs to address this. A nice improvement with v2 is that if you get `gofmt` or `goimports` violations, you can just run `golangci-lint fmt` to fix the issues instead of trying to guess what is wrong.

Finally, golangci-lint v2 disables the timeout by default so we no longer need to specify it.
