### PR TITLE
Go build improvements

### DIFF
--- a/.github/workflows/main-go-library.yaml
+++ b/.github/workflows/main-go-library.yaml
@@ -25,13 +25,6 @@ on:
       gh-token:
         description: 'GitHub token used for creating releases and pulling Go modules.'
         required: true
-    outputs:
-      artifacts:
-        description: Build result artifacts.
-        value: ${{ jobs.deploy.outputs.artifacts }}
-      metadata:
-        description: Build result metadata.
-        value: ${{ jobs.deploy.outputs.metadata }}
 
 jobs:
 
@@ -39,9 +32,6 @@ jobs:
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
-    outputs:
-      artifacts: ${{ steps.goreleaser.outputs.artifacts }}
-      metadata: ${{ steps.goreleaser.outputs.metadata }}
     steps:
 
     - name: Checkout

--- a/.github/workflows/main-go-service.yaml
+++ b/.github/workflows/main-go-service.yaml
@@ -38,12 +38,6 @@ on:
         description: 'PAT used for triggering workflows and pulling Go modules.'
         required: true
     outputs:
-      artifacts:
-        description: Build result artifacts.
-        value: ${{ jobs.deploy.outputs.artifacts }}
-      metadata:
-        description: Build result metadata.
-        value: ${{ jobs.deploy.outputs.metadata }}
       tags:
         description: Docker tags.
         value: ${{ jobs.deploy.outputs.tags }}
@@ -55,8 +49,6 @@ jobs:
     name: Deploy
     runs-on: ubuntu-latest
     outputs:
-      artifacts: ${{ steps.goreleaser.outputs.artifacts }}
-      metadata: ${{ steps.goreleaser.outputs.metadata }}
       tags: ${{ steps.meta.outputs.tags }}
     steps:
 

--- a/.github/workflows/main-go-service.yaml
+++ b/.github/workflows/main-go-service.yaml
@@ -49,7 +49,7 @@ jobs:
     name: Deploy
     runs-on: ubuntu-latest
     outputs:
-      tags: ${{ steps.meta.outputs.tags }}
+      tags: ${{ steps.docker-meta.outputs.tags }}
     steps:
 
     - name: Checkout
@@ -59,6 +59,9 @@ jobs:
       uses: gramLabs/.github/.github/actions/setup-go@main
       with:
         gh-token: ${{ secrets.gh-token }}
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
 
     - name: Run GoReleaser
       id: goreleaser
@@ -70,7 +73,7 @@ jobs:
 
     - name: Docker meta
       uses: docker/metadata-action@v5
-      id: meta
+      id: docker-meta
       with:
         images: ghcr.io/${{ github.repository }}
         flavor: latest=false
@@ -85,18 +88,15 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ github.token }}
 
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
-
     - name: Build and push
       uses: docker/build-push-action@v6
       with:
         platforms: linux/amd64
         file: ./Dockerfile
         context: ./dist/${{ fromJson(steps.goreleaser.outputs.metadata).project_name }}_linux_amd64_v1
+        tags: ${{ steps.docker-meta.outputs.tags }}
+        labels: ${{ steps.docker-meta.outputs.labels }}
         build-contexts: ${{ inputs.build-contexts }}
-        tags: ${{ steps.meta.outputs.tags }}
-        labels: ${{ steps.meta.outputs.labels }}
         cache-from: type=gha
         cache-to: type=gha
         push: true
@@ -107,5 +107,5 @@ jobs:
         GH_REPO: gramLabs/stormforge-app
         GH_TOKEN: ${{ secrets.gh-token }}
       run: |
-        tags=( ${{ steps.meta.outputs.tags }} )
+        tags=( ${{ steps.docker-meta.outputs.tags }} )
         gh workflow run promote_image.yaml -f image="${tags}" -f ref_name="${{ github.ref_name }}"

--- a/.github/workflows/pull-request-go.yaml
+++ b/.github/workflows/pull-request-go.yaml
@@ -2,6 +2,12 @@ name: Pull Request
 
 on:
   workflow_call:
+    inputs:
+      short-tests:
+        description: 'Only run short tests.'
+        default: true
+        required: false
+        type: boolean
     secrets:
       gh-token:
         description: 'PAT used for pulling Go modules.'
@@ -77,10 +83,10 @@ jobs:
         go generate ./...
         go build ./...
 
-  # Runs the short Go tests, callers may define additional jobs for more in-depth
+  # Runs the Go tests, callers may define additional jobs for more in-depth
   # acceptance testing on pull requests if necessary.
   test:
-    name: Short Tests
+    name: Test
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
@@ -91,5 +97,10 @@ jobs:
       with:
         gh-token: '${{ secrets.gh-token }}'
 
-    - name: Test
-      run: go test -short ./...
+    - name: Run Short Tests
+      if: 'inputs.short-tests'
+      run: 'go test -short ./...'
+
+    - name: Run Tests
+      if: '!inputs.short-tests'
+      run: 'go test ./...'

--- a/.github/workflows/pull-request-go.yaml
+++ b/.github/workflows/pull-request-go.yaml
@@ -72,7 +72,10 @@ jobs:
 
     - name: Run Go build
       if: hashFiles('.goreleaser.yml', '.goreleaser.yaml', 'goreleaser.yml', 'goreleaser.yaml') == ''
-      run: go build ./...
+      run: |
+        go mod tidy
+        go generate ./...
+        go build ./...
 
   # Runs the short Go tests, callers may define additional jobs for more in-depth
   # acceptance testing on pull requests if necessary.

--- a/.github/workflows/pull-request-go.yaml
+++ b/.github/workflows/pull-request-go.yaml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       short-tests:
-        description: 'Only run short tests.'
+        description: 'Limit Go Test to only running short tests.'
         default: true
         required: false
         type: boolean
@@ -15,7 +15,6 @@ on:
 
 jobs:
 
-  # Runs the linter with a minimal set of default rules.
   lint:
     name: Lint
     runs-on: ubuntu-latest
@@ -52,12 +51,11 @@ jobs:
           timeout: 10m
         EOF
 
-    - name: Lint
+    - name: Run Linter
       uses: golangci/golangci-lint-action@v8
       with:
         args: '--config="${{ runner.temp }}/.golangci.yaml"'
 
-  # Runs the build to ensure nothing is overtly broken.
   build:
     name: Build
     runs-on: ubuntu-latest
@@ -83,8 +81,7 @@ jobs:
         go generate ./...
         go build ./...
 
-  # Runs the Go tests, callers may define additional jobs for more in-depth
-  # acceptance testing on pull requests if necessary.
+  # Callers may define additional jobs for more in-depth acceptance testing on pull requests if necessary
   test:
     name: Test
     runs-on: ubuntu-latest
@@ -99,8 +96,10 @@ jobs:
 
     - name: Run Short Tests
       if: 'inputs.short-tests'
-      run: 'go test -short ./...'
+      run: |
+        go test -short ./...
 
     - name: Run Tests
       if: '!inputs.short-tests'
-      run: 'go test ./...'
+      run: |
+        go test ./...


### PR DESCRIPTION
Some minor clean up to the Go build workflows.

The main improvement is the ability to toggle between short and long tests for pull requests (e.g. so you don't need to run both).

Another change is that library and service code will stop outputting build information since these workflows are meant to be final (unlike the software builds which should have additional steps).